### PR TITLE
Add missing test for lesson

### DIFF
--- a/test/arrays-test.js
+++ b/test/arrays-test.js
@@ -83,7 +83,21 @@ describe('arrays', () => {
       expect(removeElementFromBeginningOfArray([1, 2, 3])).to.eql([2, 3])
     })
   })
-
+  
+  describe('destructivelyRemoveElementFromEndOfArray(array)', () => {
+    it('removes the last element from the `array`', () => {
+      expect(removeElementFromEndOfArray([1, 2, 3])).to.eql([1, 2])
+    })
+    
+    it('alters `array`', () => {
+      const array = [1, 2]
+      
+      destructivelyRemoveElementFromEndOfArray(array)
+      
+      expect(array).to.eql([1])
+    })
+  })
+  
   describe('removeElementFromEndOfArray(array)', () => {
     it('removes the last element from the `array`', () => {
       expect(removeElementFromEndOfArray([1, 2, 3])).to.eql([1, 2])


### PR DESCRIPTION
destructivelyRemoveElementFromEndOfArray() didn't have a test.

Added test, verifies both return value and that it does destructively alter the array that's passed in.